### PR TITLE
Fix edge case and crash in method getIntersectPoint

### DIFF
--- a/decide/src/main/java/org/example/Decide.java
+++ b/decide/src/main/java/org/example/Decide.java
@@ -118,7 +118,7 @@ public class Decide {
         double DIST = settings.PARAMETERS.DIST;
 
         return settings.NUMPOINTS >= 3
-                && IntStream.range(0, settings.NUMPOINTS - settings.PARAMETERS.N_PTS)
+                && IntStream.range(0, settings.NUMPOINTS - settings.PARAMETERS.N_PTS + 1)
                         .anyMatch((index) -> settings.POINTS[index]
                                 .isEqualTo(settings.POINTS[index + settings.PARAMETERS.N_PTS - 1])
                                         // Index + 1 because we choose the first point as the coincident point

--- a/decide/src/main/java/org/example/Point.java
+++ b/decide/src/main/java/org/example/Point.java
@@ -115,15 +115,17 @@ public class Point {
             throw new Error("p2 and p3 are the same point");
         }
 
-        // Get conflict point between p1 and p2
-        int k1 = (p3.y - p2.y) / (p3.x - p2.x);
 
-        // Edge case here when k1 is completely horizontal
-        // That will create a division by 0 if we don't have this check
-        if (k1 == 0) {
+        // Edge case here when k1 is completely horizontal (or vertical)
+        // That will create a division by 0 if we don't have this check  
+        if (p3.y == p2.y) {
+            return new Point(p2.x, y);
+        } else if (p3.x == p2.x) {
             return new Point(x, p2.y);
         }
 
+        // Get conflict point between p1 and p2
+        int k1 = (p3.y - p2.y) / (p3.x - p2.x);
         int m1 = p2.y - k1 * p2.x;
         int k2 = -1 / k1;
         int m2 = y - k2 * x;

--- a/decide/src/main/java/org/example/Point.java
+++ b/decide/src/main/java/org/example/Point.java
@@ -109,6 +109,11 @@ public class Point {
      * and the perpendicular line through "this" point.
      */
     public Point getIntersectPoint(Point p2, Point p3) {
+
+        if (p2.isEqualTo(p3)) {
+            throw new Error("p2 and p3 are the same point");
+        }
+
         // Get conflict point between p1 and p2
         int k1 = (p3.y - p2.y) / (p3.x - p2.x);
         int m1 = p2.y - k1 * p2.x;

--- a/decide/src/main/java/org/example/Point.java
+++ b/decide/src/main/java/org/example/Point.java
@@ -119,9 +119,9 @@ public class Point {
         // Edge case here when k1 is completely horizontal (or vertical)
         // That will create a division by 0 if we don't have this check  
         if (p3.y == p2.y) {
-            return new Point(p2.x, y);
-        } else if (p3.x == p2.x) {
             return new Point(x, p2.y);
+        } else if (p3.x == p2.x) {
+            return new Point(p2.x, y);
         }
 
         // Get conflict point between p1 and p2

--- a/decide/src/main/java/org/example/Point.java
+++ b/decide/src/main/java/org/example/Point.java
@@ -110,12 +110,20 @@ public class Point {
      */
     public Point getIntersectPoint(Point p2, Point p3) {
 
+        // If p2 and p3 are the same then 
         if (p2.isEqualTo(p3)) {
             throw new Error("p2 and p3 are the same point");
         }
 
         // Get conflict point between p1 and p2
         int k1 = (p3.y - p2.y) / (p3.x - p2.x);
+
+        // Edge case here when k1 is completely horizontal
+        // That will create a division by 0 if we don't have this check
+        if (k1 == 0) {
+            return new Point(x, p2.y);
+        }
+
         int m1 = p2.y - k1 * p2.x;
         int k2 = -1 / k1;
         int m2 = y - k2 * x;


### PR DESCRIPTION
Related issue #93 

Before the function crashes whenever a horizontal line was provided due to division by zero, this is now fixed by adding in an edge case check for horizontal lines, the method will now also intentionally crash if provided poitns are the same as there can be no line from one point