### PR TITLE
Fix failing true-test for condition 2

### DIFF
--- a/decide/src/test/java/org/example/DecideTest.java
+++ b/decide/src/test/java/org/example/DecideTest.java
@@ -57,7 +57,7 @@ class DecideTest {
     @Test
     void condition2_EPSILON_equals_PI_divided_by_3_angle_is_PI_divided_by_2_TRUE() {
         int numPoints = 3;
-        Point[] points = {new Point(0,1), new Point(0,0), new Point(0, 1)};
+        Point[] points = {new Point(0,1), new Point(0,0), new Point(1, 0)};
         InitialSettings.Parameters parameters = new InitialSettings.Parameters(0, 0, Math.PI/3, 0, 0, 0, 0, 0, 0, 0 , 0, 0, 0, 0,0, 0, 0, 0, 0);
         LogicalOperator[][] lcmNotUsed = new LogicalOperator[15][15];
         boolean[] puvNotUsed = new boolean[15];


### PR DESCRIPTION
Two out of three points were duplicate, thus there was no angle that was formed. Angle that was supposed to be formed was 90°, but resulting angle was undefined.

Changed one duplicate point from (0,1) to (1,0)