### PR TITLE
Fix failing true-test for condition 4

### DIFF
--- a/decide/src/main/java/org/example/Decide.java
+++ b/decide/src/main/java/org/example/Decide.java
@@ -101,7 +101,7 @@ public class Decide {
     }
 
     public boolean condition4() {
-        return IntStream.range(0, settings.NUMPOINTS - settings.PARAMETERS.Q_PTS).anyMatch(
+        return IntStream.range(0, settings.NUMPOINTS - settings.PARAMETERS.Q_PTS + 1).anyMatch(
                 (index) -> Point.quadrantRepartition(
                         Arrays.copyOfRange(settings.POINTS, index, index + settings.PARAMETERS.Q_PTS),
                         settings.PARAMETERS.QUADS));


### PR DESCRIPTION
Condition 4 method did not check the last set of consecutive Q_PTS.

End of range was changed with + 1 to account for last set of consecutive Q_PTS.

To get way initial code was wrong consider the case when we only have Q_PTS points. range will be range(0,0), an empty range.