### PR TITLE
Fix failing true-test for condition 9

### DIFF
--- a/decide/src/test/java/org/example/DecideTest.java
+++ b/decide/src/test/java/org/example/DecideTest.java
@@ -226,7 +226,7 @@ class DecideTest {
     void condition9_EPSILON_equals_PI_over_2_CPTS_equals_1_DPTS_equals_1_exists_points_TRUE() {
         int numPoints = 5;
         Point[] points = { new Point(1,0), new Point(2,1), new Point(0,0), new Point(1, 0), new Point(0,-1)};
-        InitialSettings.Parameters parameters = new InitialSettings.Parameters(0, 0, Math.PI/2, 0, 0, 0, 0, 0, 0, 0 , 0, 1, 1, 0,0, 0, 0, 0, 0);
+        InitialSettings.Parameters parameters = new InitialSettings.Parameters(0, 0, Math.PI/3, 0, 0, 0, 0, 0, 0, 0 , 0, 1, 1, 0,0, 0, 0, 0, 0);
         LogicalOperator[][] lcmNotUsed = new LogicalOperator[15][15];
         boolean[] puvNotUsed = new boolean[15];
         InitialSettings settings = new InitialSettings(numPoints, points, parameters, lcmNotUsed, puvNotUsed);


### PR DESCRIPTION
The formed angle was 90°. Epsilon was PI/2.

This should fail since conditions thus were
90° < 90°
or
90° > 270°

Epsilon was changed to PI/3, thus making the condition: 90° < 120°
or
90° > 240°