### PR TITLE
Fix failing false-test for condition 9

### DIFF
--- a/decide/src/main/java/org/example/Decide.java
+++ b/decide/src/main/java/org/example/Decide.java
@@ -165,7 +165,7 @@ public class Decide {
                                         < Math.PI - settings.PARAMETERS.EPSILON
                                     ||
                                 POINTS[index + 1 + C_PTS].angle(POINTS[index], POINTS[index + 2 + C_PTS + D_PTS])
-                                        > Math.PI - settings.PARAMETERS.EPSILON
+                                        > Math.PI + settings.PARAMETERS.EPSILON
                         )
                 )
         );


### PR DESCRIPTION
Change "-" to "+" in the method for condition 9.

Condition should check:
angle < (PI - epsilon) or angle > (PI + epsilon). See #11 

But it checked
angle < (PI - epsilon) or angle > (PI - epsilon)
